### PR TITLE
Improve ease of use by improving structure of lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 angular2-threatconnect/*
 lib/.baseDir.ts
 .tscache
-typings/*
 
 # Node generated files
 

--- a/main.ts
+++ b/main.ts
@@ -7,7 +7,12 @@ import { TcOwnerService } from './lib/tc_owner.service';
 import { TcSecurityLabelService } from './lib/tc_security_labels.service';
 import { TcUtilityService } from './lib/tc_utility.service';
 
+import { SpacesModule } from 'angular2-spaces/main';
+
 @NgModule({
+    imports: [
+        SpacesModule,
+    ],
     providers: [
         TcExchangeDbService,
         TcGroupService,

--- a/main.ts
+++ b/main.ts
@@ -1,8 +1,39 @@
-export * from './lib/tc_exchange_db.service';
-export * from './lib/tc_group.service';
-export * from './lib/tc_indicator.service';
-export * from './lib/tc_owner.service';
-export * from './lib/tc_security_labels.service';
-export * from './lib/tc_utility.service';
+import { NgModule } from '@angular/core';
+
+import { TcExchangeDbService } from './lib/tc_exchange_db.service';
+import { TcGroupService } from './lib/tc_group.service';
+import { TcIndicatorService } from './lib/tc_indicator.service';
+import { TcOwnerService } from './lib/tc_owner.service';
+import { TcSecurityLabelService } from './lib/tc_security_labels.service';
+import { TcUtilityService } from './lib/tc_utility.service';
+
+// Third part
+import { GrowlModule } from 'primeng/primeng';
+
+@NgModule({
+    imports: [
+        GrowlModule,
+    ],
+    providers: [
+        TcExchangeDbService,
+        TcGroupService,
+        TcIndicatorService,
+        TcOwnerService,
+        TcSecurityLabelService,
+        TcUtilityService,
+    ]
+})
+class TcModule { }
+
+export {
+    TcExchangeDbService,
+    TcGroupService,
+    TcIndicatorService,
+    TcOwnerService,
+    TcSecurityLabelService,
+    TcUtilityService,
+    TcModule,
+};
+
 export * from './lib/tc_resource_type';
 export * from './lib/entities';

--- a/main.ts
+++ b/main.ts
@@ -7,13 +7,7 @@ import { TcOwnerService } from './lib/tc_owner.service';
 import { TcSecurityLabelService } from './lib/tc_security_labels.service';
 import { TcUtilityService } from './lib/tc_utility.service';
 
-// Third part
-import { GrowlModule } from 'primeng/primeng';
-
 @NgModule({
-    imports: [
-        GrowlModule,
-    ],
     providers: [
         TcExchangeDbService,
         TcGroupService,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     }
   ],
   "dependencies": {
-    "angular2-spaces-src": "git+https://github.com/oBusk/angular2-spaces.git#master"
+    "angular2-spaces": "git+https://github.com/oBusk/angular2-spaces.git#master"
   },
   "description": "ThreatConnect SDK for Angular 2.",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     }
   ],
   "dependencies": {
-    "angular2-spaces": "git+https://github.com/oBusk/angular2-spaces.git#master"
+    "angular2-spaces-src": "git+https://github.com/ThreatConnect-Inc/angular2-spaces.git#master"
   },
   "description": "ThreatConnect SDK for Angular 2.",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     }
   ],
   "dependencies": {
-    "angular2-spaces-src": "git+https://github.com/ThreatConnect-Inc/angular2-spaces.git#master"
+    "angular2-spaces-src": "git+https://github.com/oBusk/angular2-spaces.git#master"
   },
   "description": "ThreatConnect SDK for Angular 2.",
   "devDependencies": {
@@ -29,6 +29,7 @@
     "@angular/platform-browser-dynamic": "2.4.5",
     "@angular/router": "3.4.5",
     "@angular/upgrade": "2.4.5",
+    "@types/core-js": "^0.9.41",
     "codelyzer": "^2.0.0-beta.4",
     "core-js": "^2.4.0",
     "grunt": "^1.0.1",
@@ -73,7 +74,6 @@
     "url": "https://github.com/ThreatConnect-Inc/angular2-threatconnect"
   },
   "scripts": {
-    "preinstall": "typings install",
     "postinstall": "tsc",
     "test": "npm test"
   },

--- a/package.json
+++ b/package.json
@@ -77,6 +77,6 @@
     "postinstall": "tsc",
     "test": "npm test"
   },
-  "typings": "dist/main.ts",
+  "typings": "dist/main.d.ts",
   "version": "0.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,6 @@
     "postinstall": "tsc",
     "test": "npm test"
   },
-  "typings": "./main.ts",
+  "typings": "dist/main.ts",
   "version": "0.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "angular2"
   ],
   "license": "Apache-2.0",
-  "main": "main.js",
+  "main": "dist/main.js",
   "maintainers": [
     {
       "email": "bsummers@threatconnect.com",
@@ -64,7 +64,7 @@
       "name": "Chris Blades"
     }
   ],
-  "name": "angular2-threatconnect-src",
+  "name": "angular2-threatconnect",
   "optionalDependencies": {},
   "peerDependencies": {},
   "readme": "",
@@ -74,9 +74,9 @@
   },
   "scripts": {
     "preinstall": "typings install",
-    "postinstall": "tsc && mv dist ../angular2-threatconnect",
+    "postinstall": "tsc",
     "test": "npm test"
   },
-  "typings": "./typings/index.d.ts",
+  "typings": "./main.ts",
   "version": "0.1.0"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-        "declaration": true,
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "module": "commonjs",
@@ -17,6 +16,7 @@
         "./main.ts"
     ],
     "exclude": [
+        "dist",
         "node_modules"
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "declaration": false,
+        "declaration": true,
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "module": "commonjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,26 @@
 {
     "compilerOptions": {
+        "declaration": false,
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "module": "commonjs",
+        "moduleResolution": "node",
         "noImplicitAny": false,
         "outDir": "dist",
         "removeComments": false,
         "sourceMap": false,
-        "target": "ES5"
+        "target": "es5",
+        "typeRoots": [
+            "node_modules/@types"
+        ],
+        "lib": [
+            "es2016",
+            "dom"
+        ]
     },
     "compileOnSave": false,
     "buildOnSave": false,
     "files": [
-        "./typings/index.d.ts",
         "./main.ts"
     ],
     "exclude": [

--- a/typings.json
+++ b/typings.json
@@ -1,7 +1,0 @@
-{
-  "globalDependencies": {
-    "core-js": "registry:dt/core-js#0.9.7+20161130133742",
-    "jasmine": "registry:dt/jasmine#2.5.0+20170117213604",
-    "marked": "registry:dt/marked#0.0.0+20160510002910"
-  }
-}


### PR DESCRIPTION
We believe these changes would make the angular2-spaces lib easier to import and use.

We have not changed any of the functionality, only structure, typing and exports.

**The changes in this PR is dependent on the changes in https://github.com/ThreatConnect-Inc/angular2-spaces/pull/3**

* Stop moving directories when compiling lib.
* Stop using `typings` lib since it can cause conflicts with the proper @types.
* Export `TcModule` to allow easier bootstraping in angular.